### PR TITLE
Unify impl-specific link relations

### DIFF
--- a/src/main/java/org/trellisldp/api/Resource.java
+++ b/src/main/java/org/trellisldp/api/Resource.java
@@ -14,11 +14,14 @@
 package org.trellisldp.api;
 
 import static java.util.Collections.singleton;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
 import static java.util.Optional.empty;
 
 import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -142,13 +145,24 @@ public interface Resource {
     }
 
     /**
+     * Get any extra implementation-defined link relations for this resource.
+     *
+     * @return a map of relation types
+     */
+    default Map<String, List<String>> getExtraLinkRelations() {
+        return emptyMap();
+    }
+
+    /**
      * Get the ldp:inbox for this resource, if one exists
      *
      * <p>Note: if an ldp:inbox value does not exist for this resource,
      * an empty {@link Optional} value will be returned.</p>
      *
      * @return the ldp:inbox IRI
+     * @deprecated use {@link getExtraLinkRelations} instead.
      */
+    @Deprecated
     default Optional<IRI> getInbox() {
         return empty();
     }
@@ -156,8 +170,12 @@ public interface Resource {
     /**
      * Get the rdf:type(s) for this resource
      * @return a collection of RDF Types
+     * @deprecated use {@link getExtraLinkRelations} instead.
      */
-    Collection<IRI> getTypes();
+    @Deprecated
+    default Collection<IRI> getTypes() {
+        return emptyList();
+    }
 
     /**
      * Get the IRI for the resource's annotation service
@@ -166,7 +184,9 @@ public interface Resource {
      * an empty {@link Optional} value will be returned.</p>
      *
      * @return the annotation service
+     * @deprecated use {@link getExtraLinkRelations} instead.
      */
+    @Deprecated
     default Optional<IRI> getAnnotationService() {
         return empty();
     }

--- a/src/test/java/org/trellisldp/api/ResourceTest.java
+++ b/src/test/java/org/trellisldp/api/ResourceTest.java
@@ -18,6 +18,7 @@ import static java.util.stream.Stream.empty;
 import static java.util.stream.Stream.of;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.Mockito.doCallRealMethod;
@@ -51,6 +52,7 @@ public class ResourceTest {
     private Resource mockResource;
 
     @BeforeEach
+    @SuppressWarnings("deprecation")
     public void setUp() {
         initMocks(this);
         doCallRealMethod().when(mockResource).getMembershipResource();
@@ -63,11 +65,14 @@ public class ResourceTest {
         doCallRealMethod().when(mockResource).isMemento();
         doCallRealMethod().when(mockResource).getInbox();
         doCallRealMethod().when(mockResource).getAnnotationService();
+        doCallRealMethod().when(mockResource).getTypes();
+        doCallRealMethod().when(mockResource).getExtraLinkRelations();
 
         when(mockResource.stream()).thenAnswer((x) -> empty());
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void testResource() {
         assertEquals(0L, mockResource.stream(prefer).count());
         assertEquals(0L, mockResource.stream(singleton(prefer)).count());
@@ -80,9 +85,12 @@ public class ResourceTest {
         assertFalse(mockResource.isMemento());
         assertFalse(mockResource.getInbox().isPresent());
         assertFalse(mockResource.getAnnotationService().isPresent());
+        assertTrue(mockResource.getTypes().isEmpty());
+        assertTrue(mockResource.getExtraLinkRelations().isEmpty());
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void testResource2() {
         final IRI subject = rdf.createIRI("ex:subject");
         when(mockResource.stream()).thenAnswer((x) -> of(
@@ -100,5 +108,7 @@ public class ResourceTest {
         assertFalse(mockResource.isMemento());
         assertFalse(mockResource.getInbox().isPresent());
         assertFalse(mockResource.getAnnotationService().isPresent());
+        assertTrue(mockResource.getTypes().isEmpty());
+        assertTrue(mockResource.getExtraLinkRelations().isEmpty());
     }
 }


### PR DESCRIPTION
@ajs6f do you have any thoughts on this? The idea would be to generalize the `getInbox`, `getAnnotationService` and `getTypes` into a single (optional) method that an individual implementation could choose to implement.